### PR TITLE
Added package.json for NPM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "jquery.mousehold",
+  "version": "1.0.0",
+  "description": "Mousehold event for jQuery.",
+  "main": "jquery.mousehold.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yansern/jquery.mousehold.git"
+  },
+  "keywords": [
+    "jquery",
+    "mouse",
+    "event",
+    "mousehold"
+  ],
+  "author": "Yan Sern (hey@yansern.io)",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/yansern/jquery.mousehold/issues"
+  },
+  "homepage": "https://github.com/yansern/jquery.mousehold#readme"
+}


### PR DESCRIPTION
Hi, Yan!

One bioinformatical library (https://github.com/wtsi-web/Genoverse) is using your mousehold plugin and we need an NPM package for it.

Thus I took the liberty to create a package.json file for your plugin in order to publish it as an NPM package. Would you mind?

I'll publish jquery.mousehold myself for the sake of urgency now, but I'll transfer ownership of the NPM package to you via: https://docs.npmjs.com/cli/owner as soon as you're ready.

Thanks!